### PR TITLE
Hacktoberfest 2020: Added links for contributors and fixed character encoding warning

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8" />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
@@ -39,28 +40,44 @@
       <tr>
         <td width="3%">1</td>
         <td width="15%">Ye Lynn Khant</td>
-        <td width="15%">https://github.com/yelynn1</td>
+        <td width="15%">
+          <a href="https://github.com/yelynn1">
+            https://github.com/yelynn1
+          </a>
+        </td>
         <td width="20%">Initiated this project</td>
       </tr>
 
       <tr>
         <td>2</td>
         <td>Prasanna S S</td>
-        <td>https://github.com/prasannassp</td>
+        <td>
+          <a href="https://github.com/prasannassp">
+            https://github.com/prasannassp
+          </a>
+        </td>
         <td>Added contributors.html</td>
       </tr>
 
       <tr>
         <td>3</td>
         <td>Yash Ajgaonkar</td>
-        <td>https://github.com/yash2189</td>
+        <td>
+          <a href="https://github.com/yash2189">
+            https://github.com/yash2189
+          </a>
+        </td>
         <td>Documentation</td>
       </tr>
 
       <tr>
         <td>4</td>
         <td>ArshdeepSingh98</td>
-        <td>https://github.com/ArshdeepSingh98</td>
+        <td>
+          <a href="https://github.com/ArshdeepSingh98">
+            https://github.com/ArshdeepSingh98
+          </a>
+        </td>
         <td>Styling contributors</td>
       </tr>
 


### PR DESCRIPTION
I made the contributor names links so it's easier to see the contributor's github. I also fixed a console warning by defining the character encoding for the contributors HTML. I hope this helps!
<img width="561" alt="console-warning" src="https://user-images.githubusercontent.com/18430971/97117459-4c141c00-16da-11eb-9f3b-465a9debdb21.png">
 