### PR TITLE
Added Margin to volume slider to prevent overlap

### DIFF
--- a/style.css
+++ b/style.css
@@ -92,6 +92,10 @@ button:hover {
   color: white;
 }
 
+#volume-slider{
+  margin-left: 5px;
+}
+
 .play-area {
   display: grid;
   width: 300px;


### PR DESCRIPTION
When clicking the "Play music" button, the extra border that was added would cause overlap between the slider.  I added a margin of 5px to the left side of the slider to keep it separated.